### PR TITLE
fix(ci): refresh wme-sdk-typings integrity hash in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10299,9 +10299,9 @@
       }
     },
     "node_modules/wme-sdk-typings": {
-      "version": "v2.354-12-gb93d6042ba",
+      "version": "v2.354-13-g0e5fdd812d",
       "resolved": "https://web-assets.waze.com/wme_sdk_docs/production/latest/wme-sdk-typings.tgz",
-      "integrity": "sha512-esUSJVPnV9j9nZK1abSYxrZBSOVDxexC9o0dhVJC31vxvITNUUGeEYlwCKdQEJ25Blq9WmAoY6vzRK/zMKLK+w==",
+      "integrity": "sha512-EzbtbkG6U3FCutGvD8tsBvJr5X4NRPEQuTZD83KrI+CdqyMczmj9pq88V21XcsN1ckBN7uMf2wFOM4qJBs6mMg==",
       "dev": true,
       "license": "UNLICENSED",
       "peerDependencies": {


### PR DESCRIPTION
## Problem

The `v1.4.0` release workflow failed at `npm ci` with:

```
npm error code EINTEGRITY
wme-sdk-typings ... wanted sha512-esUSJ... but got sha512-EzbtbkG6...
```

`wme-sdk-typings` is fetched from a non-versioned Waze URL (`.../latest/wme-sdk-typings.tgz`). Waze republished the tarball, so the pinned sha512 in `package-lock.json` no longer matches.

## Fix

Refresh the lockfile entry to the current tarball:
- version `v2.354-12-gb93d6042ba` -> `v2.354-13-g0e5fdd812d`
- integrity sha512 updated to the live tarball hash

Verified locally: `npm ci` now exits 0. Not related to any app code.

## Follow-up

After merge, re-point the `v1.4.0` tag to the new main HEAD to re-trigger the release build.